### PR TITLE
feat: add Ray and Angle classes

### DIFF
--- a/lib/geo2d/angle.rb
+++ b/lib/geo2d/angle.rb
@@ -1,52 +1,74 @@
 # frozen_string_literal: true
 
-# Класс для работы с углами
+# Represents an angle with normalization to [0, 2π)
 class Angle
   attr_reader :radians
 
-  # Создаёт угол в радианах с нормализацией в [0, 2π)
+  # Creates an angle in radians, normalized to [0, 2π)
+  #
+  # @param radians [Float] angle in radians
+  # @return [Angle] new Angle instance
   def initialize(radians)
     @radians = radians % (2 * Math::PI)
   end
 
-  # Создаёт угол из градусов
+  # Creates an angle from degrees
+  #
+  # @param degrees [Float] angle in degrees
+  # @return [Angle] new Angle instance
   def self.from_degrees(degrees)
     new(degrees * Math::PI / 180.0)
   end
 
-  # Возвращает угол в градусах
+  # Returns the angle in degrees
+  #
+  # @return [Float] angle in degrees
   def degrees
     radians * 180.0 / Math::PI
   end
 
-  # Проверка, является ли угол острым (< 90°)
+  # Returns true if the angle is acute (< 90°)
+  #
+  # @return [Boolean]
   def acute?
-    radians > 0 && radians < Math::PI / 2
+    radians.positive? && radians < Math::PI / 2
   end
 
-  # Проверка, является ли угол прямым (90°)
+  # Returns true if the angle is right (90°)
+  #
+  # @return [Boolean]
   def right?
-    (radians - Math::PI / 2).abs < 1e-10
+    (radians - (Math::PI / 2)).abs < 1e-10
   end
 
-  # Проверка, является ли угол тупым (> 90° и < 180°)
+  # Returns true if the angle is obtuse (> 90° and < 180°)
+  #
+  # @return [Boolean]
   def obtuse?
     radians > Math::PI / 2 && radians < Math::PI
   end
 
-  # Проверка, является ли угол развёрнутым (180°)
+  # Returns true if the angle is straight (180°)
+  #
+  # @return [Boolean]
   def straight?
     (radians - Math::PI).abs < 1e-10
   end
 
-  # Проверка, является ли угол рефлекторным (> 180°)
+  # Returns true if the angle is reflex (> 180°)
+  #
+  # @return [Boolean]
   def reflex?
     radians > Math::PI
   end
 
-  # Сравнение углов с учётом погрешности
+  # Compares two angles with epsilon precision
+  #
+  # @param other [Angle] other angle to compare
+  # @return [Boolean]
   def ==(other)
     return false unless other.is_a?(Angle)
+
     (radians - other.radians).abs < 1e-10
   end
 end

--- a/lib/geo2d/angle.rb
+++ b/lib/geo2d/angle.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Класс для работы с углами
+class Angle
+  attr_reader :radians
+
+  # Создаёт угол в радианах с нормализацией в [0, 2π)
+  def initialize(radians)
+    @radians = radians % (2 * Math::PI)
+  end
+
+  # Создаёт угол из градусов
+  def self.from_degrees(degrees)
+    new(degrees * Math::PI / 180.0)
+  end
+
+  # Возвращает угол в градусах
+  def degrees
+    radians * 180.0 / Math::PI
+  end
+
+  # Проверка, является ли угол острым (< 90°)
+  def acute?
+    radians > 0 && radians < Math::PI / 2
+  end
+
+  # Проверка, является ли угол прямым (90°)
+  def right?
+    (radians - Math::PI / 2).abs < 1e-10
+  end
+
+  # Проверка, является ли угол тупым (> 90° и < 180°)
+  def obtuse?
+    radians > Math::PI / 2 && radians < Math::PI
+  end
+
+  # Проверка, является ли угол развёрнутым (180°)
+  def straight?
+    (radians - Math::PI).abs < 1e-10
+  end
+
+  # Проверка, является ли угол рефлекторным (> 180°)
+  def reflex?
+    radians > Math::PI
+  end
+
+  # Сравнение углов с учётом погрешности
+  def ==(other)
+    return false unless other.is_a?(Angle)
+    (radians - other.radians).abs < 1e-10
+  end
+end

--- a/lib/geo2d/ray.rb
+++ b/lib/geo2d/ray.rb
@@ -3,111 +3,133 @@
 require_relative 'point'
 require_relative 'angle'
 
-# Класс для работы с лучом (полупрямой)
+# Represents a ray (half-line) defined by an origin point and direction angle
 class Ray
   attr_reader :origin, :direction_angle
 
-  # Создаёт луч по начальной точке и углу направления
+  # Creates a ray from an origin point and direction angle
+  #
+  # @param origin [Geo2d::Point] the starting point of the ray
+  # @param direction_angle [Angle] the direction of the ray
+  # @raise [ArgumentError] if origin is not a Point or direction_angle is not an Angle
   def initialize(origin, direction_angle)
     raise ArgumentError, 'Origin must be a Point' unless origin.is_a?(Geo2d::Point)
     raise ArgumentError, 'Direction angle must be an Angle' unless direction_angle.is_a?(Angle)
-    
+
     @origin = origin
     @direction_angle = direction_angle
   end
 
-  # Создаёт луч по двум точкам
+  # Creates a ray from two points
+  #
+  # @param point1 [Geo2d::Point] the origin point
+  # @param point2 [Geo2d::Point] any point on the ray (different from origin)
+  # @return [Ray] a new ray pointing from point1 through point2
+  # @raise [ArgumentError] if points are not distinct or not Point objects
   def self.from_points(point1, point2)
     raise ArgumentError, 'Both arguments must be Point' unless point1.is_a?(Geo2d::Point) && point2.is_a?(Geo2d::Point)
     raise ArgumentError, 'Points must be distinct' if point1 == point2
-    
+
     dx = point2.x - point1.x
     dy = point2.y - point1.y
     radians = Math.atan2(dy, dx)
     angle = Angle.new(radians)
-    
+
     new(point1, angle)
   end
 
-  # Возвращает единичный вектор направления
+  # Returns the unit direction vector of the ray
+  #
+  # @return [Geo2d::Point] unit vector representing direction
   def direction_vector
     x = Math.cos(direction_angle.radians)
     y = Math.sin(direction_angle.radians)
     Geo2d::Point.new(x, y)
   end
 
-  # Возвращает точку на луче на заданном расстоянии от начала
+  # Returns a point on the ray at the given distance from origin
+  #
+  # @param distance [Float] non-negative distance from origin
+  # @return [Geo2d::Point] point at the specified distance
+  # @raise [ArgumentError] if distance is negative
   def point_at(distance)
-    raise ArgumentError, 'distance must be non-negative' if distance < 0
-    
+    raise ArgumentError, 'Distance must be non-negative' if distance.negative?
+
     vector = direction_vector
-    x = origin.x + vector.x * distance
-    y = origin.y + vector.y * distance
+    x = origin.x + (vector.x * distance)
+    y = origin.y + (vector.y * distance)
     Geo2d::Point.new(x, y)
   end
 
-  # Проверяет, принадлежит ли точка лучу
+  # rubocop:disable Metrics/AbcSize
+  # Checks if a point lies on the ray
+  #
+  # @param point [Geo2d::Point] the point to check
+  # @return [Boolean] true if point is on the ray
   def contains_point?(point)
     return false unless point.is_a?(Geo2d::Point)
-    
+
     dx = point.x - origin.x
     dy = point.y - origin.y
-    
-    # Если точка совпадает с началом луча
+
     return true if dx.abs < 1e-10 && dy.abs < 1e-10
-    
-    # Вычисляем угол от начала луча до точки
+
     point_angle = Math.atan2(dy, dx)
-    point_angle += 2 * Math::PI if point_angle < 0
-    
+    point_angle += 2 * Math::PI if point_angle.negative?
+
     ray_angle = direction_angle.radians
-    
-    # Проверяем сонаправленность с учётом погрешности
+
     angle_diff = (point_angle - ray_angle).abs
-    angle_diff = 2 * Math::PI - angle_diff if angle_diff > Math::PI
-    
-    # Проверяем, что точка лежит в том же направлении
+    angle_diff = (2 * Math::PI) - angle_diff if angle_diff > Math::PI
+
     return false unless angle_diff < 1e-10
-    
-    # Проверяем, что точка не находится "перед" началом луча
-    # Для этого проверяем, что скалярное произведение вектора направления
-    # и вектора к точке положительно
+
     dir_vector = direction_vector
-    dot_product = dx * dir_vector.x + dy * dir_vector.y
-    
+    dot_product = (dx * dir_vector.x) + (dy * dir_vector.y)
+
     dot_product > -1e-10
   end
+  # rubocop:enable Metrics/AbcSize
 
-  # Проверка параллельности двух лучей
+  # Checks if two rays are parallel
+  #
+  # @param other [Ray] the other ray to compare
+  # @return [Boolean] true if rays are parallel
   def parallel?(other)
     return false unless other.is_a?(Ray)
-    
+
     angle1 = direction_angle.radians
     angle2 = other.direction_angle.radians
-    
+
     diff = (angle1 - angle2).abs
-    diff = 2 * Math::PI - diff if diff > Math::PI
-    
+    diff = (2 * Math::PI) - diff if diff > Math::PI
+
     diff < 1e-10 || (diff - Math::PI).abs < 1e-10
   end
 
-  # Проверка перпендикулярности двух лучей
+  # Checks if two rays are perpendicular
+  #
+  # @param other [Ray] the other ray to compare
+  # @return [Boolean] true if rays are perpendicular
   def perpendicular?(other)
     return false unless other.is_a?(Ray)
-    
+
     angle1 = direction_angle.radians
     angle2 = other.direction_angle.radians
-    
+
     diff = (angle1 - angle2).abs
-    diff = 2 * Math::PI - diff if diff > Math::PI
-    
-    (diff - Math::PI / 2).abs < 1e-10
+    diff = (2 * Math::PI) - diff if diff > Math::PI
+
+    (diff - (Math::PI / 2)).abs < 1e-10
   end
 
-  # Сравнение лучей
+  # Compares two rays for equality
+  #
+  # @param other [Ray] the other ray to compare
+  # @return [Boolean] true if rays have same origin and direction
   def ==(other)
     return false unless other.is_a?(Ray)
-    
+
     origin == other.origin && direction_angle == other.direction_angle
   end
 end

--- a/lib/geo2d/ray.rb
+++ b/lib/geo2d/ray.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require_relative 'point'
+require_relative 'angle'
+
+# Класс для работы с лучом (полупрямой)
+class Ray
+  attr_reader :origin, :direction_angle
+
+  # Создаёт луч по начальной точке и углу направления
+  def initialize(origin, direction_angle)
+    raise ArgumentError, 'Origin must be a Point' unless origin.is_a?(Geo2d::Point)
+    raise ArgumentError, 'Direction angle must be an Angle' unless direction_angle.is_a?(Angle)
+    
+    @origin = origin
+    @direction_angle = direction_angle
+  end
+
+  # Создаёт луч по двум точкам
+  def self.from_points(point1, point2)
+    raise ArgumentError, 'Both arguments must be Point' unless point1.is_a?(Geo2d::Point) && point2.is_a?(Geo2d::Point)
+    raise ArgumentError, 'Points must be distinct' if point1 == point2
+    
+    dx = point2.x - point1.x
+    dy = point2.y - point1.y
+    radians = Math.atan2(dy, dx)
+    angle = Angle.new(radians)
+    
+    new(point1, angle)
+  end
+
+  # Возвращает единичный вектор направления
+  def direction_vector
+    x = Math.cos(direction_angle.radians)
+    y = Math.sin(direction_angle.radians)
+    Geo2d::Point.new(x, y)
+  end
+
+  # Возвращает точку на луче на заданном расстоянии от начала
+  def point_at(distance)
+    raise ArgumentError, 'distance must be non-negative' if distance < 0
+    
+    vector = direction_vector
+    x = origin.x + vector.x * distance
+    y = origin.y + vector.y * distance
+    Geo2d::Point.new(x, y)
+  end
+
+  # Проверяет, принадлежит ли точка лучу
+  def contains_point?(point)
+    return false unless point.is_a?(Geo2d::Point)
+    
+    dx = point.x - origin.x
+    dy = point.y - origin.y
+    
+    # Если точка совпадает с началом луча
+    return true if dx.abs < 1e-10 && dy.abs < 1e-10
+    
+    # Вычисляем угол от начала луча до точки
+    point_angle = Math.atan2(dy, dx)
+    point_angle += 2 * Math::PI if point_angle < 0
+    
+    ray_angle = direction_angle.radians
+    
+    # Проверяем сонаправленность с учётом погрешности
+    angle_diff = (point_angle - ray_angle).abs
+    angle_diff = 2 * Math::PI - angle_diff if angle_diff > Math::PI
+    
+    # Проверяем, что точка лежит в том же направлении
+    return false unless angle_diff < 1e-10
+    
+    # Проверяем, что точка не находится "перед" началом луча
+    # Для этого проверяем, что скалярное произведение вектора направления
+    # и вектора к точке положительно
+    dir_vector = direction_vector
+    dot_product = dx * dir_vector.x + dy * dir_vector.y
+    
+    dot_product > -1e-10
+  end
+
+  # Проверка параллельности двух лучей
+  def parallel?(other)
+    return false unless other.is_a?(Ray)
+    
+    angle1 = direction_angle.radians
+    angle2 = other.direction_angle.radians
+    
+    diff = (angle1 - angle2).abs
+    diff = 2 * Math::PI - diff if diff > Math::PI
+    
+    diff < 1e-10 || (diff - Math::PI).abs < 1e-10
+  end
+
+  # Проверка перпендикулярности двух лучей
+  def perpendicular?(other)
+    return false unless other.is_a?(Ray)
+    
+    angle1 = direction_angle.radians
+    angle2 = other.direction_angle.radians
+    
+    diff = (angle1 - angle2).abs
+    diff = 2 * Math::PI - diff if diff > Math::PI
+    
+    (diff - Math::PI / 2).abs < 1e-10
+  end
+
+  # Сравнение лучей
+  def ==(other)
+    return false unless other.is_a?(Ray)
+    
+    origin == other.origin && direction_angle == other.direction_angle
+  end
+end

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../lib/geo2d/angle'
+
+describe Angle do
+  # 1. КОНСТРУКТОРЫ
+  describe '#initialize' do
+    it 'создаёт угол с радианами' do
+      angle = Angle.new(Math::PI)
+      expect(angle.radians).to eq(Math::PI)
+    end
+
+    it 'нормализует угол в диапазон [0, 2π)' do
+      angle1 = Angle.new(3 * Math::PI)
+      angle2 = Angle.new(-Math::PI / 2)
+      expect(angle1.radians).to be_within(1e-10).of(Math::PI)
+      expect(angle2.radians).to be_within(1e-10).of(3 * Math::PI / 2)
+    end
+  end
+
+  describe '.from_degrees' do
+    it 'создаёт угол из градусов' do
+      angle = Angle.from_degrees(180)
+      expect(angle.radians).to be_within(1e-10).of(Math::PI)
+    end
+
+    it 'нормализует градусы > 360' do
+      angle = Angle.from_degrees(540)
+      expect(angle.radians).to be_within(1e-10).of(Math::PI)
+    end
+
+    it 'нормализует отрицательные градусы' do
+      angle = Angle.from_degrees(-90)
+      expect(angle.radians).to be_within(1e-10).of(3 * Math::PI / 2)
+    end
+  end

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -32,3 +32,20 @@ describe Angle do
       expect(angle.radians).to be_within(1e-10).of(3 * Math::PI / 2)
     end
   end
+    # 2. СВОЙСТВА
+  describe '#degrees' do
+    it 'возвращает угол в градусах' do
+      angle = Angle.new(Math::PI / 2)
+      expect(angle.degrees).to be_within(1e-10).of(90)
+    end
+
+    it 'возвращает нормализованное значение для углов > 360°' do
+      angle = Angle.from_degrees(450)
+      expect(angle.degrees).to be_within(1e-10).of(90)
+    end
+  end
+
+    
+    
+
+  

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/geo2d/angle'
+require_relative '../lib/geo2d/angle'
 
 describe Angle do
   # 1. КОНСТРУКТОРЫ

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../lib/geo2d/angle'
 
 describe Angle do
@@ -32,7 +34,8 @@ describe Angle do
       expect(angle.radians).to be_within(1e-10).of(3 * Math::PI / 2)
     end
   end
-    # 2. СВОЙСТВА
+
+  # 2. СВОЙСТВА
   describe '#degrees' do
     it 'возвращает угол в градусах' do
       angle = Angle.new(Math::PI / 2)
@@ -44,7 +47,8 @@ describe Angle do
       expect(angle.degrees).to be_within(1e-10).of(90)
     end
   end
-   # 3. ПРЕДИКАТЫ
+
+  # 3. ПРЕДИКАТЫ
   describe '#acute?' do
     it 'возвращает true для острого угла (< 90°)' do
       expect(Angle.new(Math::PI / 4)).to be_acute
@@ -106,7 +110,8 @@ describe Angle do
       expect(Angle.new(Math::PI)).not_to be_reflex
     end
   end
-   # 4. ГРАНИЧНЫЕ СЛУЧАИ
+
+  # 4. ГРАНИЧНЫЕ СЛУЧАИ
   describe 'сравнение углов' do
     it 'считает равными углы с разницей меньше EPSILON' do
       angle1 = Angle.new(Math::PI / 2)
@@ -133,7 +138,4 @@ describe Angle do
     end
   end
 end
-    
-    
-
   

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -106,6 +106,33 @@ describe Angle do
       expect(Angle.new(Math::PI)).not_to be_reflex
     end
   end
+   # 4. ГРАНИЧНЫЕ СЛУЧАИ
+  describe 'сравнение углов' do
+    it 'считает равными углы с разницей меньше EPSILON' do
+      angle1 = Angle.new(Math::PI / 2)
+      angle2 = Angle.new(Math::PI / 2 + 1e-11)
+      expect(angle1).to eq(angle2)
+    end
+
+    it 'считает разные углы неравными' do
+      angle1 = Angle.new(Math::PI / 4)
+      angle2 = Angle.new(Math::PI / 2)
+      expect(angle1).not_to eq(angle2)
+    end
+  end
+
+  describe 'нормализация больших углов' do
+    it 'корректно нормализует угол 720°' do
+      angle = Angle.from_degrees(720)
+      expect(angle.degrees).to be_within(1e-10).of(0)
+    end
+
+    it 'корректно нормализует угол -360°' do
+      angle = Angle.from_degrees(-360)
+      expect(angle.degrees).to be_within(1e-10).of(0)
+    end
+  end
+end
     
     
 

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -44,7 +44,68 @@ describe Angle do
       expect(angle.degrees).to be_within(1e-10).of(90)
     end
   end
+   # 3. ПРЕДИКАТЫ
+  describe '#acute?' do
+    it 'возвращает true для острого угла (< 90°)' do
+      expect(Angle.new(Math::PI / 4)).to be_acute
+    end
 
+    it 'возвращает false для прямого угла' do
+      expect(Angle.new(Math::PI / 2)).not_to be_acute
+    end
+
+    it 'возвращает false для тупого угла' do
+      expect(Angle.new(3 * Math::PI / 4)).not_to be_acute
+    end
+  end
+
+  describe '#right?' do
+    it 'возвращает true для прямого угла (90°)' do
+      expect(Angle.new(Math::PI / 2)).to be_right
+    end
+
+    it 'возвращает false для острого угла' do
+      expect(Angle.new(Math::PI / 4)).not_to be_right
+    end
+
+    it 'возвращает false для тупого угла' do
+      expect(Angle.new(3 * Math::PI / 4)).not_to be_right
+    end
+  end
+
+  describe '#obtuse?' do
+    it 'возвращает true для тупого угла (90° < angle < 180°)' do
+      expect(Angle.new(3 * Math::PI / 4)).to be_obtuse
+    end
+
+    it 'возвращает false для острого угла' do
+      expect(Angle.new(Math::PI / 4)).not_to be_obtuse
+    end
+
+    it 'возвращает false для прямого угла' do
+      expect(Angle.new(Math::PI / 2)).not_to be_obtuse
+    end
+  end
+
+  describe '#straight?' do
+    it 'возвращает true для развёрнутого угла (180°)' do
+      expect(Angle.new(Math::PI)).to be_straight
+    end
+
+    it 'возвращает false для других углов' do
+      expect(Angle.new(Math::PI / 2)).not_to be_straight
+    end
+  end
+
+  describe '#reflex?' do
+    it 'возвращает true для рефлекторного угла (> 180°)' do
+      expect(Angle.new(5 * Math::PI / 4)).to be_reflex
+    end
+
+    it 'возвращает false для угла <= 180°' do
+      expect(Angle.new(Math::PI)).not_to be_reflex
+    end
+  end
     
     
 

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -3,14 +3,14 @@
 require_relative '../lib/geo2d/angle'
 
 describe Angle do
-  # 1. КОНСТРУКТОРЫ
+  # 1. CONSTRUCTORS
   describe '#initialize' do
-    it 'создаёт угол с радианами' do
+    it 'creates an angle with radians' do
       angle = Angle.new(Math::PI)
       expect(angle.radians).to eq(Math::PI)
     end
 
-    it 'нормализует угол в диапазон [0, 2π)' do
+    it 'normalizes angle to [0, 2π)' do
       angle1 = Angle.new(3 * Math::PI)
       angle2 = Angle.new(-Math::PI / 2)
       expect(angle1.radians).to be_within(1e-10).of(Math::PI)
@@ -19,123 +19,122 @@ describe Angle do
   end
 
   describe '.from_degrees' do
-    it 'создаёт угол из градусов' do
+    it 'creates an angle from degrees' do
       angle = Angle.from_degrees(180)
       expect(angle.radians).to be_within(1e-10).of(Math::PI)
     end
 
-    it 'нормализует градусы > 360' do
+    it 'normalizes degrees greater than 360' do
       angle = Angle.from_degrees(540)
       expect(angle.radians).to be_within(1e-10).of(Math::PI)
     end
 
-    it 'нормализует отрицательные градусы' do
+    it 'normalizes negative degrees' do
       angle = Angle.from_degrees(-90)
       expect(angle.radians).to be_within(1e-10).of(3 * Math::PI / 2)
     end
   end
 
-  # 2. СВОЙСТВА
+  # 2. PROPERTIES
   describe '#degrees' do
-    it 'возвращает угол в градусах' do
+    it 'returns angle in degrees' do
       angle = Angle.new(Math::PI / 2)
       expect(angle.degrees).to be_within(1e-10).of(90)
     end
 
-    it 'возвращает нормализованное значение для углов > 360°' do
+    it 'returns normalized value for angles greater than 360 degrees' do
       angle = Angle.from_degrees(450)
       expect(angle.degrees).to be_within(1e-10).of(90)
     end
   end
 
-  # 3. ПРЕДИКАТЫ
+  # 3. PREDICATES
   describe '#acute?' do
-    it 'возвращает true для острого угла (< 90°)' do
+    it 'returns true for acute angle less than 90 degrees' do
       expect(Angle.new(Math::PI / 4)).to be_acute
     end
 
-    it 'возвращает false для прямого угла' do
+    it 'returns false for right angle' do
       expect(Angle.new(Math::PI / 2)).not_to be_acute
     end
 
-    it 'возвращает false для тупого угла' do
+    it 'returns false for obtuse angle' do
       expect(Angle.new(3 * Math::PI / 4)).not_to be_acute
     end
   end
 
   describe '#right?' do
-    it 'возвращает true для прямого угла (90°)' do
+    it 'returns true for right angle of 90 degrees' do
       expect(Angle.new(Math::PI / 2)).to be_right
     end
 
-    it 'возвращает false для острого угла' do
+    it 'returns false for acute angle' do
       expect(Angle.new(Math::PI / 4)).not_to be_right
     end
 
-    it 'возвращает false для тупого угла' do
+    it 'returns false for obtuse angle' do
       expect(Angle.new(3 * Math::PI / 4)).not_to be_right
     end
   end
 
   describe '#obtuse?' do
-    it 'возвращает true для тупого угла (90° < angle < 180°)' do
+    it 'returns true for obtuse angle between 90 and 180 degrees' do
       expect(Angle.new(3 * Math::PI / 4)).to be_obtuse
     end
 
-    it 'возвращает false для острого угла' do
+    it 'returns false for acute angle' do
       expect(Angle.new(Math::PI / 4)).not_to be_obtuse
     end
 
-    it 'возвращает false для прямого угла' do
+    it 'returns false for right angle' do
       expect(Angle.new(Math::PI / 2)).not_to be_obtuse
     end
   end
 
   describe '#straight?' do
-    it 'возвращает true для развёрнутого угла (180°)' do
+    it 'returns true for straight angle of 180 degrees' do
       expect(Angle.new(Math::PI)).to be_straight
     end
 
-    it 'возвращает false для других углов' do
+    it 'returns false for other angles' do
       expect(Angle.new(Math::PI / 2)).not_to be_straight
     end
   end
 
   describe '#reflex?' do
-    it 'возвращает true для рефлекторного угла (> 180°)' do
+    it 'returns true for reflex angle greater than 180 degrees' do
       expect(Angle.new(5 * Math::PI / 4)).to be_reflex
     end
 
-    it 'возвращает false для угла <= 180°' do
+    it 'returns false for angle less than or equal to 180 degrees' do
       expect(Angle.new(Math::PI)).not_to be_reflex
     end
   end
 
-  # 4. ГРАНИЧНЫЕ СЛУЧАИ
-  describe 'сравнение углов' do
-    it 'считает равными углы с разницей меньше EPSILON' do
+  # 4. EDGE CASES
+  describe 'angle comparison' do
+    it 'considers angles equal within epsilon tolerance' do
       angle1 = Angle.new(Math::PI / 2)
-      angle2 = Angle.new(Math::PI / 2 + 1e-11)
+      angle2 = Angle.new((Math::PI / 2) + 1e-11)
       expect(angle1).to eq(angle2)
     end
 
-    it 'считает разные углы неравными' do
+    it 'considers different angles unequal' do
       angle1 = Angle.new(Math::PI / 4)
       angle2 = Angle.new(Math::PI / 2)
       expect(angle1).not_to eq(angle2)
     end
   end
 
-  describe 'нормализация больших углов' do
-    it 'корректно нормализует угол 720°' do
+  describe 'normalization of large angles' do
+    it 'normalizes 720 degrees to 0 degrees' do
       angle = Angle.from_degrees(720)
       expect(angle.degrees).to be_within(1e-10).of(0)
     end
 
-    it 'корректно нормализует угол -360°' do
+    it 'normalizes -360 degrees to 0 degrees' do
       angle = Angle.from_degrees(-360)
       expect(angle.degrees).to be_within(1e-10).of(0)
     end
   end
 end
-  

--- a/spec/ray_spec.rb
+++ b/spec/ray_spec.rb
@@ -5,116 +5,116 @@ require_relative '../lib/geo2d/angle'
 require_relative '../lib/geo2d/ray'
 
 describe Ray do
-  # 1. КОНСТРУКТОРЫ
+  # 1. CONSTRUCTORS
   describe '#initialize' do
-    it 'создаёт луч по точке и углу' do
+    it 'creates a ray from point and angle' do
       origin = Geo2d::Point.new(0, 0)
       angle = Angle.new(Math::PI / 4)
       ray = Ray.new(origin, angle)
-      
+
       expect(ray.origin).to eq(origin)
       expect(ray.direction_angle).to eq(angle)
     end
 
-    it 'выбрасывает ошибку, если origin не Point' do
+    it 'raises error when origin is not a Point' do
       expect { Ray.new([0, 0], Angle.new(0)) }.to raise_error(ArgumentError, /must be a Point/)
     end
 
-    it 'выбрасывает ошибку, если angle не Angle' do
+    it 'raises error when angle is not an Angle' do
       expect { Ray.new(Geo2d::Point.new(0, 0), 45) }.to raise_error(ArgumentError, /must be an Angle/)
     end
   end
 
   describe '.from_points' do
-    it 'создаёт луч из двух точек' do
+    it 'creates a ray from two points' do
       point1 = Geo2d::Point.new(0, 0)
       point2 = Geo2d::Point.new(3, 3)
       ray = Ray.from_points(point1, point2)
-      
+
       expect(ray.origin).to eq(point1)
       expect(ray.direction_angle.radians).to be_within(1e-10).of(Math::PI / 4)
     end
 
-    it 'выбрасывает ошибку, если точки совпадают' do
+    it 'raises error when points are identical' do
       point = Geo2d::Point.new(1, 1)
       expect { Ray.from_points(point, point) }.to raise_error(ArgumentError, /must be distinct/)
     end
 
-    it 'выбрасывает ошибку, если аргументы не Point' do
+    it 'raises error when arguments are not Points' do
       expect { Ray.from_points([0, 0], Geo2d::Point.new(1, 1)) }.to raise_error(ArgumentError, /must be Point/)
     end
   end
 
-  # 2. СВОЙСТВА
+  # 2. PROPERTIES
   describe '#point_at' do
     let(:origin) { Geo2d::Point.new(0, 0) }
     let(:angle) { Angle.from_degrees(45) }
     let(:ray) { Ray.new(origin, angle) }
 
-    it 'возвращает точку на заданном расстоянии' do
+    it 'returns a point at the given distance' do
       point = ray.point_at(Math.sqrt(2))
       expect(point.x).to be_within(1e-10).of(1)
       expect(point.y).to be_within(1e-10).of(1)
     end
 
-    it 'возвращает начальную точку при distance = 0' do
+    it 'returns the origin point when distance is zero' do
       point = ray.point_at(0)
       expect(point).to eq(origin)
     end
 
-    it 'выбрасывает ошибку при отрицательном расстоянии' do
-      expect { ray.point_at(-5) }.to raise_error(ArgumentError, /distance must be non-negative/)
+    it 'raises error when distance is negative' do
+      expect { ray.point_at(-5) }.to raise_error(ArgumentError, /Distance must be non-negative/)
     end
   end
 
   describe '#direction_vector' do
     let(:origin) { Geo2d::Point.new(0, 0) }
-    
-    it 'возвращает единичный вектор направления' do
+
+    it 'returns a unit direction vector' do
       angle = Angle.from_degrees(90)
       ray = Ray.new(origin, angle)
       vector = ray.direction_vector
-      
+
       expect(vector.x).to be_within(1e-10).of(0)
       expect(vector.y).to be_within(1e-10).of(1)
     end
 
-    it 'возвращает вектор длины 1' do
+    it 'returns a vector of length 1' do
       angle = Angle.from_degrees(30)
       ray = Ray.new(origin, angle)
       vector = ray.direction_vector
-      
-      length = Math.sqrt(vector.x**2 + vector.y**2)
+
+      length = Math.sqrt((vector.x**2) + (vector.y**2))
       expect(length).to be_within(1e-10).of(1)
     end
   end
 
-  # 3. ПРЕДИКАТЫ
+  # 3. PREDICATES
   describe '#contains_point?' do
     let(:origin) { Geo2d::Point.new(0, 0) }
     let(:angle) { Angle.from_degrees(45) }
     let(:ray) { Ray.new(origin, angle) }
 
-    it 'возвращает true для точки на луче' do
+    it 'returns true for a point on the ray' do
       point = Geo2d::Point.new(2, 2)
       expect(ray.contains_point?(point)).to eq(true)
     end
 
-    it 'возвращает true для начальной точки' do
+    it 'returns true for the origin point' do
       expect(ray.contains_point?(origin)).to eq(true)
     end
 
-    it 'возвращает false для точки не на луче' do
+    it 'returns false for a point not on the ray' do
       point = Geo2d::Point.new(-1, 1)
       expect(ray.contains_point?(point)).to eq(false)
     end
 
-    it 'возвращает false для точки в направлении, но перед началом' do
+    it 'returns false for a point in the direction but before the origin' do
       point = Geo2d::Point.new(-2, -2)
       expect(ray.contains_point?(point)).to eq(false)
     end
 
-    it 'возвращает false для точки с правильным направлением, но смещением' do
+    it 'returns false for a point with correct direction but offset' do
       point = Geo2d::Point.new(2, 3)
       expect(ray.contains_point?(point)).to eq(false)
     end
@@ -125,17 +125,17 @@ describe Ray do
     let(:angle) { Angle.from_degrees(45) }
     let(:ray1) { Ray.new(origin, angle) }
 
-    it 'возвращает true для лучей с одинаковым направлением' do
+    it 'returns true for rays with same direction' do
       ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(45))
       expect(ray1.parallel?(ray2)).to eq(true)
     end
 
-    it 'возвращает true для лучей с противоположным направлением' do
+    it 'returns true for rays with opposite direction' do
       ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(225))
       expect(ray1.parallel?(ray2)).to eq(true)
     end
 
-    it 'возвращает false для лучей с разным направлением' do
+    it 'returns false for rays with different direction' do
       ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(90))
       expect(ray1.parallel?(ray2)).to eq(false)
     end
@@ -145,45 +145,45 @@ describe Ray do
     let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray1) { Ray.new(origin, Angle.from_degrees(45)) }
 
-    it 'возвращает true для перпендикулярного луча' do
+    it 'returns true for perpendicular ray' do
       ray2 = Ray.new(origin, Angle.from_degrees(135))
       expect(ray1.perpendicular?(ray2)).to eq(true)
     end
 
-    it 'возвращает false для не перпендикулярного луча' do
+    it 'returns false for non-perpendicular ray' do
       ray2 = Ray.new(origin, Angle.from_degrees(60))
       expect(ray1.perpendicular?(ray2)).to eq(false)
     end
   end
 
-  # 4. ГРАНИЧНЫЕ СЛУЧАИ
-  describe 'горизонтальный луч' do
+  # 4. EDGE CASES
+  describe 'horizontal ray' do
     let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray) { Ray.new(origin, Angle.from_degrees(0)) }
 
-    it 'корректно находит точки' do
+    it 'correctly finds points' do
       point = ray.point_at(5)
       expect(point.x).to eq(5)
       expect(point.y).to eq(0)
     end
 
-    it 'корректно проверяет принадлежность' do
+    it 'correctly checks point membership' do
       expect(ray.contains_point?(Geo2d::Point.new(10, 0))).to eq(true)
       expect(ray.contains_point?(Geo2d::Point.new(10, 1))).to eq(false)
     end
   end
 
-  describe 'вертикальный луч' do
+  describe 'vertical ray' do
     let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray) { Ray.new(origin, Angle.from_degrees(90)) }
 
-    it 'корректно находит точки' do
+    it 'correctly finds points' do
       point = ray.point_at(5)
       expect(point.x).to be_within(1e-10).of(0)
       expect(point.y).to be_within(1e-10).of(5)
     end
 
-    it 'корректно проверяет принадлежность' do
+    it 'correctly checks point membership' do
       expect(ray.contains_point?(Geo2d::Point.new(0, 10))).to eq(true)
       expect(ray.contains_point?(Geo2d::Point.new(1, 10))).to eq(false)
     end

--- a/spec/ray_spec.rb
+++ b/spec/ray_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require_relative '../lib/geo2d/ray'
+require_relative '../lib/geo2d/point'
 require_relative '../lib/geo2d/angle'
+require_relative '../lib/geo2d/ray'
 
 describe Ray do
   # 1. КОНСТРУКТОРЫ
   describe '#initialize' do
     it 'создаёт луч по точке и углу' do
-      origin = Point.new(0, 0)
+      origin = Geo2d::Point.new(0, 0)
       angle = Angle.new(Math::PI / 4)
       ray = Ray.new(origin, angle)
       
@@ -20,14 +21,14 @@ describe Ray do
     end
 
     it 'выбрасывает ошибку, если angle не Angle' do
-      expect { Ray.new(Point.new(0, 0), 45) }.to raise_error(ArgumentError, /must be an Angle/)
+      expect { Ray.new(Geo2d::Point.new(0, 0), 45) }.to raise_error(ArgumentError, /must be an Angle/)
     end
   end
 
   describe '.from_points' do
     it 'создаёт луч из двух точек' do
-      point1 = Point.new(0, 0)
-      point2 = Point.new(3, 3)
+      point1 = Geo2d::Point.new(0, 0)
+      point2 = Geo2d::Point.new(3, 3)
       ray = Ray.from_points(point1, point2)
       
       expect(ray.origin).to eq(point1)
@@ -35,18 +36,18 @@ describe Ray do
     end
 
     it 'выбрасывает ошибку, если точки совпадают' do
-      point = Point.new(1, 1)
+      point = Geo2d::Point.new(1, 1)
       expect { Ray.from_points(point, point) }.to raise_error(ArgumentError, /must be distinct/)
     end
 
     it 'выбрасывает ошибку, если аргументы не Point' do
-      expect { Ray.from_points([0, 0], Point.new(1, 1)) }.to raise_error(ArgumentError, /must be Point/)
+      expect { Ray.from_points([0, 0], Geo2d::Point.new(1, 1)) }.to raise_error(ArgumentError, /must be Point/)
     end
   end
 
   # 2. СВОЙСТВА
   describe '#point_at' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:angle) { Angle.from_degrees(45) }
     let(:ray) { Ray.new(origin, angle) }
 
@@ -67,7 +68,7 @@ describe Ray do
   end
 
   describe '#direction_vector' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     
     it 'возвращает единичный вектор направления' do
       angle = Angle.from_degrees(90)
@@ -90,12 +91,12 @@ describe Ray do
 
   # 3. ПРЕДИКАТЫ
   describe '#contains_point?' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:angle) { Angle.from_degrees(45) }
     let(:ray) { Ray.new(origin, angle) }
 
     it 'возвращает true для точки на луче' do
-      point = Point.new(2, 2)
+      point = Geo2d::Point.new(2, 2)
       expect(ray.contains_point?(point)).to eq(true)
     end
 
@@ -104,44 +105,44 @@ describe Ray do
     end
 
     it 'возвращает false для точки не на луче' do
-      point = Point.new(-1, 1)
+      point = Geo2d::Point.new(-1, 1)
       expect(ray.contains_point?(point)).to eq(false)
     end
 
     it 'возвращает false для точки в направлении, но перед началом' do
-      point = Point.new(-2, -2)
+      point = Geo2d::Point.new(-2, -2)
       expect(ray.contains_point?(point)).to eq(false)
     end
 
     it 'возвращает false для точки с правильным направлением, но смещением' do
-      point = Point.new(2, 3)
+      point = Geo2d::Point.new(2, 3)
       expect(ray.contains_point?(point)).to eq(false)
     end
   end
 
   describe '#parallel?' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:angle) { Angle.from_degrees(45) }
     let(:ray1) { Ray.new(origin, angle) }
 
     it 'возвращает true для лучей с одинаковым направлением' do
-      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(45))
+      ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(45))
       expect(ray1.parallel?(ray2)).to eq(true)
     end
 
     it 'возвращает true для лучей с противоположным направлением' do
-      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(225))
+      ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(225))
       expect(ray1.parallel?(ray2)).to eq(true)
     end
 
     it 'возвращает false для лучей с разным направлением' do
-      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(90))
+      ray2 = Ray.new(Geo2d::Point.new(5, 5), Angle.from_degrees(90))
       expect(ray1.parallel?(ray2)).to eq(false)
     end
   end
 
   describe '#perpendicular?' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray1) { Ray.new(origin, Angle.from_degrees(45)) }
 
     it 'возвращает true для перпендикулярного луча' do
@@ -157,7 +158,7 @@ describe Ray do
 
   # 4. ГРАНИЧНЫЕ СЛУЧАИ
   describe 'горизонтальный луч' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray) { Ray.new(origin, Angle.from_degrees(0)) }
 
     it 'корректно находит точки' do
@@ -167,24 +168,24 @@ describe Ray do
     end
 
     it 'корректно проверяет принадлежность' do
-      expect(ray.contains_point?(Point.new(10, 0))).to eq(true)
-      expect(ray.contains_point?(Point.new(10, 1))).to eq(false)
+      expect(ray.contains_point?(Geo2d::Point.new(10, 0))).to eq(true)
+      expect(ray.contains_point?(Geo2d::Point.new(10, 1))).to eq(false)
     end
   end
 
   describe 'вертикальный луч' do
-    let(:origin) { Point.new(0, 0) }
+    let(:origin) { Geo2d::Point.new(0, 0) }
     let(:ray) { Ray.new(origin, Angle.from_degrees(90)) }
 
     it 'корректно находит точки' do
       point = ray.point_at(5)
-      expect(point.x).to eq(0)
-      expect(point.y).to eq(5)
+      expect(point.x).to be_within(1e-10).of(0)
+      expect(point.y).to be_within(1e-10).of(5)
     end
 
     it 'корректно проверяет принадлежность' do
-      expect(ray.contains_point?(Point.new(0, 10))).to eq(true)
-      expect(ray.contains_point?(Point.new(1, 10))).to eq(false)
+      expect(ray.contains_point?(Geo2d::Point.new(0, 10))).to eq(true)
+      expect(ray.contains_point?(Geo2d::Point.new(1, 10))).to eq(false)
     end
   end
 end

--- a/spec/ray_spec.rb
+++ b/spec/ray_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require_relative '../lib/geo2d/ray'
+require_relative '../lib/geo2d/angle'
+
+describe Ray do
+  # 1. КОНСТРУКТОРЫ
+  describe '#initialize' do
+    it 'создаёт луч по точке и углу' do
+      origin = Point.new(0, 0)
+      angle = Angle.new(Math::PI / 4)
+      ray = Ray.new(origin, angle)
+      
+      expect(ray.origin).to eq(origin)
+      expect(ray.direction_angle).to eq(angle)
+    end
+
+    it 'выбрасывает ошибку, если origin не Point' do
+      expect { Ray.new([0, 0], Angle.new(0)) }.to raise_error(ArgumentError, /must be a Point/)
+    end
+
+    it 'выбрасывает ошибку, если angle не Angle' do
+      expect { Ray.new(Point.new(0, 0), 45) }.to raise_error(ArgumentError, /must be an Angle/)
+    end
+  end
+
+  describe '.from_points' do
+    it 'создаёт луч из двух точек' do
+      point1 = Point.new(0, 0)
+      point2 = Point.new(3, 3)
+      ray = Ray.from_points(point1, point2)
+      
+      expect(ray.origin).to eq(point1)
+      expect(ray.direction_angle.radians).to be_within(1e-10).of(Math::PI / 4)
+    end
+
+    it 'выбрасывает ошибку, если точки совпадают' do
+      point = Point.new(1, 1)
+      expect { Ray.from_points(point, point) }.to raise_error(ArgumentError, /must be distinct/)
+    end
+
+    it 'выбрасывает ошибку, если аргументы не Point' do
+      expect { Ray.from_points([0, 0], Point.new(1, 1)) }.to raise_error(ArgumentError, /must be Point/)
+    end
+  end
+
+  # 2. СВОЙСТВА
+  describe '#point_at' do
+    let(:origin) { Point.new(0, 0) }
+    let(:angle) { Angle.from_degrees(45) }
+    let(:ray) { Ray.new(origin, angle) }
+
+    it 'возвращает точку на заданном расстоянии' do
+      point = ray.point_at(Math.sqrt(2))
+      expect(point.x).to be_within(1e-10).of(1)
+      expect(point.y).to be_within(1e-10).of(1)
+    end
+
+    it 'возвращает начальную точку при distance = 0' do
+      point = ray.point_at(0)
+      expect(point).to eq(origin)
+    end
+
+    it 'выбрасывает ошибку при отрицательном расстоянии' do
+      expect { ray.point_at(-5) }.to raise_error(ArgumentError, /distance must be non-negative/)
+    end
+  end
+
+  describe '#direction_vector' do
+    let(:origin) { Point.new(0, 0) }
+    
+    it 'возвращает единичный вектор направления' do
+      angle = Angle.from_degrees(90)
+      ray = Ray.new(origin, angle)
+      vector = ray.direction_vector
+      
+      expect(vector.x).to be_within(1e-10).of(0)
+      expect(vector.y).to be_within(1e-10).of(1)
+    end
+
+    it 'возвращает вектор длины 1' do
+      angle = Angle.from_degrees(30)
+      ray = Ray.new(origin, angle)
+      vector = ray.direction_vector
+      
+      length = Math.sqrt(vector.x**2 + vector.y**2)
+      expect(length).to be_within(1e-10).of(1)
+    end
+  end
+
+  # 3. ПРЕДИКАТЫ
+  describe '#contains_point?' do
+    let(:origin) { Point.new(0, 0) }
+    let(:angle) { Angle.from_degrees(45) }
+    let(:ray) { Ray.new(origin, angle) }
+
+    it 'возвращает true для точки на луче' do
+      point = Point.new(2, 2)
+      expect(ray.contains_point?(point)).to eq(true)
+    end
+
+    it 'возвращает true для начальной точки' do
+      expect(ray.contains_point?(origin)).to eq(true)
+    end
+
+    it 'возвращает false для точки не на луче' do
+      point = Point.new(-1, 1)
+      expect(ray.contains_point?(point)).to eq(false)
+    end
+
+    it 'возвращает false для точки в направлении, но перед началом' do
+      point = Point.new(-2, -2)
+      expect(ray.contains_point?(point)).to eq(false)
+    end
+
+    it 'возвращает false для точки с правильным направлением, но смещением' do
+      point = Point.new(2, 3)
+      expect(ray.contains_point?(point)).to eq(false)
+    end
+  end
+
+  describe '#parallel?' do
+    let(:origin) { Point.new(0, 0) }
+    let(:angle) { Angle.from_degrees(45) }
+    let(:ray1) { Ray.new(origin, angle) }
+
+    it 'возвращает true для лучей с одинаковым направлением' do
+      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(45))
+      expect(ray1.parallel?(ray2)).to eq(true)
+    end
+
+    it 'возвращает true для лучей с противоположным направлением' do
+      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(225))
+      expect(ray1.parallel?(ray2)).to eq(true)
+    end
+
+    it 'возвращает false для лучей с разным направлением' do
+      ray2 = Ray.new(Point.new(5, 5), Angle.from_degrees(90))
+      expect(ray1.parallel?(ray2)).to eq(false)
+    end
+  end
+
+  describe '#perpendicular?' do
+    let(:origin) { Point.new(0, 0) }
+    let(:ray1) { Ray.new(origin, Angle.from_degrees(45)) }
+
+    it 'возвращает true для перпендикулярного луча' do
+      ray2 = Ray.new(origin, Angle.from_degrees(135))
+      expect(ray1.perpendicular?(ray2)).to eq(true)
+    end
+
+    it 'возвращает false для не перпендикулярного луча' do
+      ray2 = Ray.new(origin, Angle.from_degrees(60))
+      expect(ray1.perpendicular?(ray2)).to eq(false)
+    end
+  end
+
+  # 4. ГРАНИЧНЫЕ СЛУЧАИ
+  describe 'горизонтальный луч' do
+    let(:origin) { Point.new(0, 0) }
+    let(:ray) { Ray.new(origin, Angle.from_degrees(0)) }
+
+    it 'корректно находит точки' do
+      point = ray.point_at(5)
+      expect(point.x).to eq(5)
+      expect(point.y).to eq(0)
+    end
+
+    it 'корректно проверяет принадлежность' do
+      expect(ray.contains_point?(Point.new(10, 0))).to eq(true)
+      expect(ray.contains_point?(Point.new(10, 1))).to eq(false)
+    end
+  end
+
+  describe 'вертикальный луч' do
+    let(:origin) { Point.new(0, 0) }
+    let(:ray) { Ray.new(origin, Angle.from_degrees(90)) }
+
+    it 'корректно находит точки' do
+      point = ray.point_at(5)
+      expect(point.x).to eq(0)
+      expect(point.y).to eq(5)
+    end
+
+    it 'корректно проверяет принадлежность' do
+      expect(ray.contains_point?(Point.new(0, 10))).to eq(true)
+      expect(ray.contains_point?(Point.new(1, 10))).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## What's done
- Add Angle class with normalization to [0, 2π)
- Add Ray class with origin point and direction angle
- Implement core methods: #point_at, #contains_point?, #parallel?, #perpendicular?
- Add RSpec tests with 4 groups (constructors, properties, predicates, edge cases)

## How to verify
- [ ] bundle exec rspec spec/angle_spec.rb
- [ ] bundle exec rspec spec/ray_spec.rb

## Example
```ruby
angle = Angle.from_degrees(45)
ray = Ray.new(Geo2d::Point.new(0,0), angle)
ray.point_at(10) # => Point(7.07, 7.07)