### PR TITLE
feat: add right_triangle entity with good test coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Layout/EndOfLine:
     - 'lib/geo2d/line.rb'
     - 'lib/geo2d/polygon.rb'
     - 'lib/geo2d/ray.rb'
+    - 'lib/geo2d/triangle.rb'
     - 'lib/geo2d/vector.rb'
     - 'spec/point_spec.rb'
     - 'spec/segment_spec.rb'
@@ -46,6 +47,7 @@ Layout/EndOfLine:
     - 'spec/polygon_spec.rb'
     - 'spec/ray_spec.rb'
     - 'spec/spec_helper.rb'
+    - 'spec/triangle_spec.rb'
     - 'spec/vector_spec.rb'
 
 Metrics/AbcSize:

--- a/lib/geo2d.rb
+++ b/lib/geo2d.rb
@@ -5,6 +5,7 @@ require_relative 'geo2d/point'
 require_relative 'geo2d/segment'
 require_relative 'geo2d/polygon'
 require_relative 'geo2d/triangle'
+require_relative 'geo2d/right_triangle'
 
 module Geo2d
   EPSILON = 1e-10

--- a/lib/geo2d/right_triangle.rb
+++ b/lib/geo2d/right_triangle.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative 'triangle'
+
+module Geo2d
+  class RightTriangle < Triangle
+    def initialize(a, b, c)
+      super
+      validate_right_triangle
+    end
+
+    def hypotenuse
+      side_lengths.max
+    end
+
+    def legs
+      sides = side_lengths.sort
+      [sides[0], sides[1]]
+    end
+
+    def right?
+      true
+    end
+
+    def equilateral?
+      false
+    end
+
+    private
+
+    def validate_right_triangle
+      raise ArgumentError, 'Not a right triangle' unless right_triangle?
+    end
+
+    def right_triangle?
+      sides = side_lengths.sort
+      (((sides[0]**2) + (sides[1]**2)) - (sides[2]**2)).abs < EPSILON
+    end
+  end
+end

--- a/spec/right_triangle_spec.rb
+++ b/spec/right_triangle_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative '../lib/geo2d/right_triangle'
+
+describe Geo2d::RightTriangle do
+  let(:p1) { Geo2d::Point.new(0, 0) }
+  let(:p2) { Geo2d::Point.new(4, 0) }
+  let(:p3) { Geo2d::Point.new(0, 3) }
+
+  describe '#initialize' do
+    it 'создаёт прямоугольный треугольник' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.vertices_count).to eq(3)
+    end
+
+    it 'вызывает ошибку для непрямоугольного треугольника' do
+      a = Geo2d::Point.new(0, 0)
+      b = Geo2d::Point.new(2, 0)
+      c = Geo2d::Point.new(1, Math.sqrt(3))
+      expect { Geo2d::RightTriangle.new(a, b, c) }
+        .to raise_error(ArgumentError, /right triangle/)
+    end
+
+    it 'вызывает ошибку при коллинеарных точках' do
+      collinear1 = Geo2d::Point.new(0, 0)
+      collinear2 = Geo2d::Point.new(1, 1)
+      collinear3 = Geo2d::Point.new(2, 2)
+      expect { Geo2d::RightTriangle.new(collinear1, collinear2, collinear3) }
+        .to raise_error(ArgumentError, /collinear/)
+    end
+  end
+
+  describe '#right?' do
+    it 'всегда возвращает true для RightTriangle' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.right?).to be(true)
+    end
+  end
+
+  describe '#hypotenuse' do
+    it 'возвращает длину гипотенузы для треугольника 3-4-5' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.hypotenuse).to eq(5)
+    end
+
+    it 'возвращает длину гипотенузы для равнобедренного прямоугольного треугольника' do
+      a = Geo2d::Point.new(0, 0)
+      b = Geo2d::Point.new(1, 0)
+      c = Geo2d::Point.new(0, 1)
+      triangle = Geo2d::RightTriangle.new(a, b, c)
+      expect(triangle.hypotenuse).to be_within(0.01).of(Math.sqrt(2))
+    end
+  end
+
+  describe '#legs' do
+    it 'возвращает катеты для треугольника 3-4-5' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      legs = triangle.legs
+      expect(legs.sort).to eq([3.0, 4.0])
+    end
+  end
+
+  describe '#area' do
+    it 'вычисляет площадь через катеты' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.area).to eq(6.0)
+    end
+  end
+
+  describe '#equilateral?' do
+    it 'всегда возвращает false для прямоугольного треугольника' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.equilateral?).to be(false)
+    end
+  end
+
+  describe '#isosceles?' do
+    it 'возвращает true для равнобедренного прямоугольного треугольника' do
+      a = Geo2d::Point.new(0, 0)
+      b = Geo2d::Point.new(1, 0)
+      c = Geo2d::Point.new(0, 1)
+      triangle = Geo2d::RightTriangle.new(a, b, c)
+      expect(triangle.isosceles?).to be(true)
+    end
+
+    it 'возвращает false для разностороннего прямоугольного треугольника' do
+      triangle = Geo2d::RightTriangle.new(p1, p2, p3)
+      expect(triangle.isosceles?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Класс Geo2d::RightTriangle реализован и протестирован.

    Созданные файлы:
     - lib/geo2d/right_triangle.rb — класс RightTriangle, наследующий от Triangle
     - spec/right_triangle_spec.rb — 11 тестов по методологии TDD

    Иерархия классов:

     1 Geo2d::Polygon (абстрактный)
     2     └── Geo2d::Triangle
     3             └── Geo2d::RightTriangle

    Реализованные методы RightTriangle:

    ┌──────────────────────┬────────────────────────────────────────────────────────┐
    │ Метод                │ Описание                                               │
    ├──────────────────────┼────────────────────────────────────────────────────────┤
    │ #initialize(a, b, c) │ Конструктор с валидацией (проверка на прямоугольность) │
    │ #hypotenuse          │ Длина гипотенузы                                       │
    │ #legs                │ Массив катетов [a, b]                                  │
    │ #right?              │ Всегда возвращает true                                 │
    │ #equilateral?        │ Всегда возвращает false                                │
    │ #isosceles?          │ Проверка на равнобедренность                           │
    │ #area                │ Площадь (унаследован от Triangle)                      │
    │ #perimeter           │ Периметр (унаследован от Polygon)                      │
    └──────────────────────┴─────────────────────────────────────────────────────────